### PR TITLE
feat(zod): add whitelist keys parameter to register config

### DIFF
--- a/packages/zod/src/config/config.spec.ts
+++ b/packages/zod/src/config/config.spec.ts
@@ -52,7 +52,7 @@ describe("config", () => {
 			{
 				variables: {
 					APP_NOT_MISSING: "not missing",
-				}
+				},
 			},
 		);
 
@@ -75,8 +75,8 @@ describe("config", () => {
 			{
 				variables: {
 					NOT_SCOPED: "not missing",
-				}
-			}
+				},
+			},
 		);
 
 		const moduleRef = Test.createTestingModule({
@@ -99,7 +99,7 @@ describe("config", () => {
 				whitelistKeys: new Set(["NOT_SCOPED"]),
 				variables: {
 					NOT_SCOPED: "not missing",
-				}
+				},
 			},
 		);
 

--- a/packages/zod/src/config/config.ts
+++ b/packages/zod/src/config/config.ts
@@ -35,8 +35,8 @@ export type NamespacedConfigType<
 	// biome-ignore lint/suspicious/noExplicitAny: needed to prevent circular dependency during infer of the config shape
 	R extends ReturnType<typeof registerConfig<string, any, any>>,
 > = {
-		[K in R["NAMESPACE"]]: NestConfigType<R>;
-	};
+	[K in R["NAMESPACE"]]: NestConfigType<R>;
+};
 
 /**
  * Registers a config with the `ConfigModule.forFeature` for partial configuration under the provided namespace.
@@ -68,9 +68,9 @@ export function registerConfig<N extends string, C extends ConfigObject, I exten
 	namespace: ConfigNamespace<N>,
 	configSchema: ZodType<C, ZodTypeDef, I>,
 	options: {
-		whitelistKeys?: Set<string>,
-		variables?: Record<string, string | undefined>,
-	} = {}
+		whitelistKeys?: Set<string>;
+		variables?: Record<string, string | undefined>;
+	} = {},
 ) {
 	const { variables = process.env, whitelistKeys } = options;
 

--- a/packages/zod/src/internal.ts
+++ b/packages/zod/src/internal.ts
@@ -151,11 +151,14 @@ function jsonify(value: string | undefined): JsonValue | undefined {
 export function decodeVariables(
 	variables: Record<string, string | undefined>,
 	namespace: string,
-	whitelistKeys: Set<string> = new Set()
+	whitelistKeys: Set<string> = new Set(),
 ): readonly [Record<string, JsonValue | undefined>, Map<string, string>] {
 	const envKeys = new Map<string, string>();
 	const envNamespace = snakeCase(namespace).toUpperCase();
-	const relevantEnv = pickBy(variables, (_value, key) => key.startsWith(envNamespace) || whitelistKeys.has(key));
+	const relevantEnv = pickBy(
+		variables,
+		(_value, key) => key.startsWith(envNamespace) || whitelistKeys.has(key),
+	);
 	const decodedEnv = reduce(
 		relevantEnv,
 		(env, value, key) => {


### PR DESCRIPTION
## 📋 Description

Adds the option to whitelist keys into a namespace.

## 📝 Checklist

<!-- Mark items with an 'x' to indicate completion -->

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and CI/CD
- [X] I have added tests for my code

## 🚨 Breaking Changes

API: new positional argument for `whitelistKeys` in the signature of `registerConfig`.

### Migration Guide

```ts
const config = registerConfig(namespace, schema, variables);
// to
const config = registerConfig(namespace, schema, { variables });
```

## 🔍 Additional Notes

<!-- Add any other context about the pull request here -->
