### PR TITLE
fix(zod): use correct input types for schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9808,7 +9808,7 @@
 		},
 		"packages/zod": {
 			"name": "@proventuslabs/nestjs-zod",
-			"version": "1.2.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"lodash": "^4.17.21"

--- a/packages/zod/examples/config.ts
+++ b/packages/zod/examples/config.ts
@@ -8,7 +8,12 @@ import z from "zod/v4";
 const appConfig = registerConfig(
 	"app",
 	z.object({
-		port: z.number().int().min(0).max(65535).describe("The local HTTP port to bind the server to"),
+		port: z.coerce
+			.number<string | undefined>()
+			.int()
+			.min(0)
+			.max(65535)
+			.describe("The local HTTP port to bind the server to"),
 	}),
 	{
 		variables: { APP_PORT: "abc" },

--- a/packages/zod/src/config/config.spec.ts
+++ b/packages/zod/src/config/config.spec.ts
@@ -23,7 +23,7 @@ describe("config", () => {
 			"app",
 			z.object({
 				port: z.coerce
-					.number()
+					.number<string | undefined>()
 					.positive()
 					.min(0)
 					.max(65535)

--- a/packages/zod/src/config/config.ts
+++ b/packages/zod/src/config/config.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 
 import { type ConfigObject, type ConfigType as NestConfigType, registerAs } from "@nestjs/config";
 
-import type { CamelCase, JsonValue } from "type-fest";
+import type { CamelCase } from "type-fest";
 import { type $ZodType, safeParseAsync } from "zod/v4/core";
 
 import { decodeVariables, typifyError } from "../internal";
@@ -60,7 +60,7 @@ export type NamespacedConfigType<
 export function registerConfig<
 	N extends string,
 	C extends ConfigObject,
-	I extends JsonValue | unknown,
+	I extends Record<string, string | undefined>,
 >(
 	namespace: ConfigNamespace<N>,
 	configSchema: $ZodType<C, I>,


### PR DESCRIPTION
## 📋 Description

Fix the input type of register config as a "env-like" and not a JSONValue since the dropping of YAML files support.

## 📝 Checklist

<!-- Mark items with an 'x' to indicate completion -->

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and CI/CD
- [X] I have added tests for my code
