### PR TITLE
feat(zod): add `warnOnly` option

### DIFF
--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -126,6 +126,7 @@ registerConfig(namespace, zodSchema, options?)
 - `zodSchema`: Zod schema for validation
 - `options.whitelistKeys`: Environment variables to allow without namespace prefix
 - `options.variables`: Environment variables to use (defaults `process.env`)
+- `options.warnOnly`: When `true`, validation failures log a warning instead of throwing, and raw values pass through unchanged
 
 #### Whitelist Keys
 
@@ -164,7 +165,8 @@ const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
       apiKey: z.string(),
       baseUrl: z.url().default("https://api.example.com"),
       timeout: z.number().default(5000),
-    })
+    }),
+    { warnOnly: true } // optional: log warnings instead of throwing on validation failure
   ).build();
 
 @Module({

--- a/packages/zod/examples/config-warn-only.ts
+++ b/packages/zod/examples/config-warn-only.ts
@@ -1,0 +1,53 @@
+import { Logger, Module } from "@nestjs/common";
+import { ConfigModule, ConfigService, type ConfigType } from "@nestjs/config";
+import { NestFactory } from "@nestjs/core";
+import { type NamespacedConfigType, registerConfig } from "@proventuslabs/nestjs-zod";
+
+import z from "zod/v4";
+
+const appConfig = registerConfig(
+	"app",
+	z.object({
+		port: z.coerce
+			.number<string | undefined>()
+			.int()
+			.min(0)
+			.max(65535)
+			.describe("The local HTTP port to bind the server to"),
+	}),
+	{
+		variables: { APP_PORT: "abc" },
+		warnOnly: true, // logs warning instead of throwing — app still starts
+	},
+);
+
+type AppConfig = ConfigType<typeof appConfig>;
+type AppConfigNamespaced = NamespacedConfigType<typeof appConfig>;
+
+@Module({
+	imports: [
+		ConfigModule.forRoot({
+			isGlobal: true,
+			load: [appConfig],
+		}),
+	],
+})
+class AppModule {}
+
+async function bootstrap() {
+	const app = await NestFactory.create(AppModule);
+
+	const logger = new Logger();
+	app.useLogger(logger);
+
+	const configService = app.get<ConfigService<AppConfigNamespaced, true>>(ConfigService);
+	const portFromService = configService.get("app.port", { infer: true });
+
+	const appConfigObject = app.get<AppConfig>(appConfig.KEY);
+	const portFromObject = appConfigObject.port;
+
+	logger.log(`Port from service: ${portFromService}`);
+	logger.log(`Port from object: ${portFromObject}`);
+}
+
+void bootstrap();

--- a/packages/zod/examples/module-warn-only.ts
+++ b/packages/zod/examples/module-warn-only.ts
@@ -1,0 +1,65 @@
+import { Inject, Injectable, Logger, Module, type OnModuleInit, Optional } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { ZodConfigurableModuleBuilder } from "@proventuslabs/nestjs-zod";
+
+import z from "zod/v4";
+
+export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } =
+	// new ConfigurableModuleBuilder<{ timeout: number }>()
+	new ZodConfigurableModuleBuilder(
+		z.object({
+			timeout: z.number().default(100).describe("Timeout in ms"),
+			nested: z.object({ key: z.string().describe("I'm nested key") }),
+		}),
+		{ warnOnly: true }, // logs warning instead of throwing — app still starts
+	)
+		.setExtras(
+			{
+				isGlobal: true,
+			},
+			(definition, extras) => ({
+				...definition,
+				global: extras.isGlobal,
+			}),
+		)
+		.build();
+
+@Module({})
+export class DynModule extends ConfigurableModuleClass {}
+
+@Injectable()
+export class NestedService implements OnModuleInit {
+	readonly logger = new Logger(NestedService.name);
+
+	public constructor(
+		@Optional() @Inject(MODULE_OPTIONS_TOKEN) readonly options: typeof OPTIONS_TYPE,
+	) {}
+
+	onModuleInit() {
+		this.logger.log(this.options);
+	}
+}
+
+@Module({
+	providers: [NestedService],
+})
+export class NestedModule {}
+
+@Module({
+	// @ts-expect-error
+	imports: [DynModule.register({ timeout: "wtf", nested: { key: 1 } }), NestedModule],
+})
+class AppModule {}
+
+async function bootstrap() {
+	const app = await NestFactory.create(AppModule);
+
+	const logger = new Logger();
+	app.useLogger(logger);
+
+	const options = app.get<typeof OPTIONS_TYPE>(MODULE_OPTIONS_TOKEN);
+
+	logger.log(options);
+}
+
+void bootstrap();


### PR DESCRIPTION
## Summary

- Adds `warnOnly` option to both `registerConfig()` and `ZodConfigurableModuleBuilder` — when enabled, validation failures log a warning via NestJS `Logger` instead of throwing, and raw values pass through unchanged
- Deduplicates three identical try/catch blocks in `ZodConfigurableModuleBuilder` into a shared `validateOptions` helper
- Exports new `ZodConfigurableModuleBuilderOptions` interface extending `ConfigurableModuleBuilderOptions`

## Test plan

- [x] `npm test` — all 17 tests pass (5 new)
- [x] `npm run typecheck` — clean
- [x] Manual verification: invalid config with `warnOnly: true` logs warning and starts app
- [x] Manual verification: valid config with `warnOnly: true` still returns parsed/transformed data